### PR TITLE
add healthcheck and service healthy condition

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,8 +4,11 @@ services:
     build: api/.
     ports: 
       - "8000:8000"
+    healthcheck:
+      test: curl --fail http://localhost:8000 || exit 1   
 
   test:
     build: test/.
     depends_on:
-      - api
+      api:
+        condition: service_healthy


### PR DESCRIPTION
tests were failing because test service was beginning upon api container start, instead of actual service readiness. added custom healthcheck for api service it is actually serving requests, as well as setting test service to wait for that health check to pass.